### PR TITLE
add <link rel='canonical' href='https://documentation.js.org/'>

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link rel='stylesheet' href='assets/basscss.css' />
   <link rel='stylesheet' href='assets/color-brewer.css' />
+  <link rel='canonical' href='https://documentation.js.org/'>
   <script src='assets/highlight.pack.js'></script>
   <script>hljs.initHighlightingOnLoad();</script>
   <style>


### PR DESCRIPTION
helpful to tell search engines to index the HTTPS version and not https://documentation.js.org/, and not the github.io version.

REF: https://support.google.com/webmasters/answer/139066?hl=en